### PR TITLE
Tested on my local jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,23 @@ FROM linuxserver/baseimage.python
 
 MAINTAINER Sparklyballs <sparklyballs@linuxserver.io>, lonix <lonix@linuxserver.io>
 
+ENV APTLIST="libxslt1-dev libxslt1.1 libxml2-dev libxml2 libssl-dev libffi-dev python-pip python-dev libssl-dev"
+
 # set python to use utf-8 rather than ascii
 ENV PYTHONIOENCODING="UTF-8"
 
 # install pip packages
-RUN pip install mako && \
+RUN apt-get update -qy && \
+apt-get install $APTLIST -qy && \
+apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+
+# build unrar
+RUN mkdir -p /tmp/unrar && \
+curl -o /tmp/unrarsource.tar.gz -L http://rarlab.com/rar/unrarsrc-5.2.7.tar.gz && \
+tar -xvf /tmp/unrarsource.tar.gz -C /tmp/unrar --strip-components=1 && \
+cd /tmp/unrar && \
+make -f makefile && \
+install -v -m755 unrar /usr/bin && \
 apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 # Adding Custom files

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM linuxserver/baseimage.python
 
 MAINTAINER Sparklyballs <sparklyballs@linuxserver.io>, lonix <lonix@linuxserver.io>
 
-ENV APTLIST="libxslt1-dev libxslt1.1 libxml2-dev libxml2 libssl-dev libffi-dev python-pip python-dev libssl-dev"
+ENV APTLIST="python-dev"
 
 # set python to use utf-8 rather than ascii
 ENV PYTHONIOENCODING="UTF-8"
@@ -20,9 +20,6 @@ cd /tmp/unrar && \
 make -f makefile && \
 install -v -m755 unrar /usr/bin && \
 apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
-
-# install required version pyopenssl
-RUN pip install pyopenssl==0.13.1
 
 # Adding Custom files
 ADD init/ /etc/my_init.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ make -f makefile && \
 install -v -m755 unrar /usr/bin && \
 apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
+# install required version pyopenssl
+RUN pip install pyopenssl==0.13.1
+
 # Adding Custom files
 ADD init/ /etc/my_init.d/
 ADD services/ /etc/service/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,8 @@ FROM linuxserver/baseimage.python
 
 MAINTAINER Sparklyballs <sparklyballs@linuxserver.io>, lonix <lonix@linuxserver.io>
 
-ENV APTLIST="python-dev"
-
 # set python to use utf-8 rather than ascii
 ENV PYTHONIOENCODING="UTF-8"
-
-# install pip packages
-RUN apt-get update -qy && \
-apt-get install $APTLIST -qy && \
-apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 # build unrar
 RUN mkdir -p /tmp/unrar && \
@@ -29,5 +22,6 @@ RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh
 # Volumes and Ports
 VOLUME /config /downloads /tv
 EXPOSE 8081
+
 
 


### PR DESCRIPTION
as per latest guide here

http://www.htpcguides.com/install-sickrage-ubuntu-14-04/

in turn linked from the sickrage/sickrage git wiki 

later version of unrar built from source and removed uneeded mako package.
