### PR TITLE
Make git clone and pull quiet.

### DIFF
--- a/init/30_update.sh
+++ b/init/30_update.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-[[ ! -d /app/sickrage/.git ]] && (git clone https://github.com/SickRage/SickRage.git /app/sickrage && \
+[[ ! -d /app/sickrage/.git ]] && (git clone -q https://github.com/SickRage/SickRage.git /app/sickrage && \
 chown -R abc:abc /app /config)
 
 # opt out for autoupdates
 [ "$ADVANCED_DISABLEUPDATES" ] && exit 0
 
 cd /app/sickrage
-git pull
+git pull -q
 chown -R abc:abc /app /config


### PR DESCRIPTION
The log on boot is too verbose.
I will PR the baseimage-python in the same way
