### PR TITLE
Use shallow clone to speed up install

### DIFF
--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -2,7 +2,7 @@
 
 # install app
 [[ ! -d /app/sickrage/.git ]] && \
-	git clone https://github.com/SickRage/SickRage.git /app/sickrage
+	git clone --depth 1 https://github.com/SickRage/SickRage.git /app/sickrage
 
 # permissions
 chown -R abc:abc \


### PR DESCRIPTION
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)

Tried it on my local machine, and went from 2 minutes and 38 seconds to 41 seconds (just the git clone).
## Thanks, team linuxserver.io
