### PR TITLE
add nodejs package for torrentz and other providers using cfscrape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ LABEL maintainer="sparklyballs"
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
+ echo "**** install packages ****" && \
+ apk add --no-cache \
+	--repository http://nl.alpinelinux.org/alpine/edge/main \
+	nodejs && \
  echo "**** install app ****" && \
  git clone --depth=1 https://github.com/SickRage/SickRage.git /app/sickrage
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Web interface is at `<your ip>:8081` , set paths for downloads, tv-shows to matc
 
 ## Versions
 
++ **20.03.18:** In lieu of a definite fix from SR, add nodejs package for use with torrentz and other sources.
 + **12.12.17:** Rebase to alpine 3.7
 + **06.08.17:** Internal git pull instead of at runtime.
 + **25.05.17:** Rebase to alpine 3.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ use edge version of nodejs to avoid install of nodejs-npm that comes with standard branch
+ closes #29 
