### PR TITLE
Deprecation, repo replaced by sickchill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)
 
+# This image has been depreciated and replaced with [linuxserver/docker-sickchill](https://github.com/linuxserver/docker-sickchill)
+
 The [LinuxServer.io](https://linuxserver.io) team brings you another container release featuring :-
 
  * regular and timely application updates

--- a/root/etc/cont-init.d/90-config
+++ b/root/etc/cont-init.d/90-config
@@ -1,0 +1,21 @@
+#!/usr/bin/with-contenv bash
+
+echo '
+******************************************************
+******************************************************
+*                                                    *
+*                                                    *
+*          This image has been depreciated           *
+*                                                    *
+*           Use the multi-arch images at             *
+*                                                    *
+*               linuxserver/sickchill                *
+*                                                    *
+*    https://hub.docker.com/r/linuxserver/sickchill  *
+*                                                    *
+*   https://github.com/linuxserver/docker-sickchill  *
+*                                                    *
+*                                                    *
+*                                                    *
+******************************************************
+******************************************************'


### PR DESCRIPTION
To deprecate this repo, as it has been superseded by fully pipeline ready [linuxserver/sickchill](https://github.com/linuxserver/sickchill)

Closes #38 

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

